### PR TITLE
Add original team business logic

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,6 +1,8 @@
 import_file_if_available "~/.iex.exs"
 
 alias StaffNotes.Accounts
+alias StaffNotes.Accounts.Organization
+alias StaffNotes.Accounts.Team
 alias StaffNotes.Accounts.User
 alias StaffNotes.Markdown
 alias StaffNotes.Repo

--- a/lib/staff_notes/accounts/accounts.ex
+++ b/lib/staff_notes/accounts/accounts.ex
@@ -1,6 +1,17 @@
 defmodule StaffNotes.Accounts do
   @moduledoc """
-  The Accounts context.
+  Represents the business-logic layer of working with the various accounts in the Staff Notes
+  application. There are three types of accounts in Staff Notes:
+
+  * Organizations - Represents an organization that has members whose behavior and achievements
+    need to be tracked by staff users
+  * Teams - Represents a group of users with the same permission level in an organization
+  * Users - Represents a staff member of an organization who will access or author notes
+
+  Business logic specific to a particular record is typically implemented within that module. For
+  example, the logic around original teams is implemented in the `StaffNotes.Accounts.Team` module.
+  Business logic that involves multiple records, such as when a user creates an organization (see
+  the `create_org/1` function) is implemented within this module.
   """
   import Ecto.Query, warn: false
 

--- a/lib/staff_notes/accounts/accounts.ex
+++ b/lib/staff_notes/accounts/accounts.ex
@@ -29,6 +29,13 @@ defmodule StaffNotes.Accounts do
 
   @doc """
   Creates an `Ecto.Changeset` for tracking team changes.
+
+  ## Examples
+
+  ```
+  iex> change_team(team)
+  %Ecto.Changeset{source: %Team{}}
+  ```
   """
   def change_team(%Team{} = team) do
     Team.changeset(team, %{})
@@ -43,7 +50,6 @@ defmodule StaffNotes.Accounts do
   iex> change_user(user)
   %Ecto.Changeset{source: %User{}}
   ```
-
   """
   def change_user(%User{} = user) do
     User.changeset(user, %{})

--- a/lib/staff_notes/accounts/accounts.ex
+++ b/lib/staff_notes/accounts/accounts.ex
@@ -21,6 +21,35 @@ defmodule StaffNotes.Accounts do
   alias StaffNotes.Accounts.User
 
   @doc """
+  Creates an `Ecto.Changeset` for tracking organization changes.
+  """
+  def change_org(%Organization{} = org) do
+    Organization.changeset(org, %{})
+  end
+
+  @doc """
+  Creates an `Ecto.Changeset` for tracking team changes.
+  """
+  def change_team(%Team{} = team) do
+    Team.changeset(team, %{})
+  end
+
+  @doc """
+  Creates an `Ecto.Changeset` for tracking user changes.
+
+  ## Examples
+
+  ```
+  iex> change_user(user)
+  %Ecto.Changeset{source: %User{}}
+  ```
+
+  """
+  def change_user(%User{} = user) do
+    User.changeset(user, %{})
+  end
+
+  @doc """
   Creates an organization.
 
   When an organization is created:
@@ -57,44 +86,32 @@ defmodule StaffNotes.Accounts do
   end
 
   @doc """
-  Lists all teams within the organization.
-  """
-  def list_teams(%Organization{} = org) do
-    query =
-      from team in Team,
-        where: team.organization_id == ^org.id
+  Creates a user.
 
-    Repo.all(query)
+  ## Examples
+
+  ```
+  iex> create_user(%{field: value})
+  {:ok, %User{}}
+  ```
+
+  ```
+  iex> create_user(%{field: bad_value})
+  {:error, %Ecto.Changeset{}}
+  ```
+
+  """
+  def create_user(attrs \\ %{}) do
+    %User{}
+    |> User.changeset(attrs)
+    |> Repo.insert()
   end
 
   @doc """
-  Returns the original team for the organization, if it exists.
-
-  This shouldn't be susceptible to race conditions so long as the original team is **always**
-  created along with the organization.
+  Deletes the organization.
   """
-  def original_team(organization_id) do
-    query =
-      from team in Team,
-      where: [original: true, organization_id: ^organization_id]
-
-    Repo.one(query)
-  end
-
-  @doc """
-  Gets the team by id.
-  """
-  def get_team!(id), do: Repo.get!(Team, id)
-
-  @doc """
-  Updates the team.
-
-  See `StaffNotes.Accounts.Team.update_team_changeset/2` for applicable business rules.
-  """
-  def update_team(%Team{} = team, attrs) do
-    team
-    |> Team.update_team_changeset(attrs)
-    |> Repo.update()
+  def delete_org(%Organization{} = org) do
+    Repo.delete(org)
   end
 
   @doc """
@@ -109,38 +126,23 @@ defmodule StaffNotes.Accounts do
   end
 
   @doc """
-  Creates a changeset for the team.
-  """
-  def change_team(%Team{} = team) do
-    Team.changeset(team, %{})
-  end
-
-  @doc """
-  Returns the list of organizations.
+  Deletes a user.
 
   ## Examples
 
   ```
-  iex> list_orgs()
-  [%Organization{}, ...]
+  iex> delete_user(user)
+  {:ok, %User{}}
   ```
+
+  ```
+  iex> delete_user(user)
+  {:error, %Ecto.Changeset{}}
+  ```
+
   """
-  def list_orgs do
-    Repo.all(Organization)
-  end
-
-  @doc """
-  Returns the list of users.
-
-  ## Examples
-
-  ```
-  iex> list_users()
-  [%User{}, ...]
-  ```
-  """
-  def list_users do
-    Repo.all(User)
+  def delete_user(%User{} = user) do
+    Repo.delete(user)
   end
 
   @doc """
@@ -149,6 +151,11 @@ defmodule StaffNotes.Accounts do
   Raises `Ecto.NoResultsError` if the organization does not exist.
   """
   def get_org!(id), do: Repo.get!(Organization, id)
+
+  @doc """
+  Gets the team by id.
+  """
+  def get_team!(id), do: Repo.get!(Team, id)
 
   @doc """
   Gets a single user.
@@ -182,30 +189,75 @@ defmodule StaffNotes.Accounts do
   def get_user!(id) when is_integer(id), do: Repo.get!(User, id)
 
   @doc """
-  Creates a user.
+  Returns the list of organizations.
 
   ## Examples
 
   ```
-  iex> create_user(%{field: value})
-  {:ok, %User{}}
+  iex> list_orgs()
+  [%Organization{}, ...]
   ```
-
-  ```
-  iex> create_user(%{field: bad_value})
-  {:error, %Ecto.Changeset{}}
-  ```
-
   """
-  def create_user(attrs \\ %{}) do
-    %User{}
-    |> User.changeset(attrs)
-    |> Repo.insert()
+  def list_orgs do
+    Repo.all(Organization)
   end
 
+  @doc """
+  Lists all teams within the organization.
+  """
+  def list_teams(%Organization{} = org) do
+    query =
+      from team in Team,
+        where: team.organization_id == ^org.id
+
+    Repo.all(query)
+  end
+
+  @doc """
+  Returns the list of users.
+
+  ## Examples
+
+  ```
+  iex> list_users()
+  [%User{}, ...]
+  ```
+  """
+  def list_users do
+    Repo.all(User)
+  end
+
+  @doc """
+  Returns the original team for the organization, if it exists.
+
+  This shouldn't be susceptible to race conditions so long as the original team is **always**
+  created along with the organization.
+  """
+  def original_team(organization_id) do
+    query =
+      from team in Team,
+      where: [original: true, organization_id: ^organization_id]
+
+    Repo.one(query)
+  end
+
+  @doc """
+  Updates the organization.
+  """
   def update_org(%Organization{} = org, attrs) do
     org
     |> Organization.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Updates the team.
+
+  See `StaffNotes.Accounts.Team.update_team_changeset/2` for applicable business rules.
+  """
+  def update_team(%Team{} = team, attrs) do
+    team
+    |> Team.update_team_changeset(attrs)
     |> Repo.update()
   end
 
@@ -229,48 +281,5 @@ defmodule StaffNotes.Accounts do
     user
     |> User.changeset(attrs)
     |> Repo.update()
-  end
-
-  def delete_org(%Organization{} = org) do
-    Repo.delete(org)
-  end
-
-  @doc """
-  Deletes a user.
-
-  ## Examples
-
-  ```
-  iex> delete_user(user)
-  {:ok, %User{}}
-  ```
-
-  ```
-  iex> delete_user(user)
-  {:error, %Ecto.Changeset{}}
-  ```
-
-  """
-  def delete_user(%User{} = user) do
-    Repo.delete(user)
-  end
-
-  def change_org(%Organization{} = org) do
-    Organization.changeset(org, %{})
-  end
-
-  @doc """
-  Returns an `%Ecto.Changeset{}` for tracking user changes.
-
-  ## Examples
-
-  ```
-  iex> change_user(user)
-  %Ecto.Changeset{source: %User{}}
-  ```
-
-  """
-  def change_user(%User{} = user) do
-    User.changeset(user, %{})
   end
 end

--- a/lib/staff_notes/accounts/accounts.ex
+++ b/lib/staff_notes/accounts/accounts.ex
@@ -15,7 +15,6 @@ defmodule StaffNotes.Accounts do
   """
   import Ecto.Query, warn: false
 
-  alias Ecto.Changeset
   alias StaffNotes.Repo
   alias StaffNotes.Accounts.Organization
   alias StaffNotes.Accounts.Team
@@ -43,8 +42,7 @@ defmodule StaffNotes.Accounts do
   @doc """
   Creates a team within an organization.
 
-  Will not create a team with `original` set to `true` if one already exists within the
-  organization.
+  See `StaffNotes.Accounts.Team.create_team_changeset/2` for applicable business rules.
   """
   def create_team(team_attrs \\ %{}, %Organization{} = org) do
     team_attrs
@@ -91,7 +89,7 @@ defmodule StaffNotes.Accounts do
   @doc """
   Updates the team.
 
-  Will not allow a team's `original` field to be changed.
+  See `StaffNotes.Accounts.Team.update_team_changeset/2` for applicable business rules.
   """
   def update_team(%Team{} = team, attrs) do
     team
@@ -102,19 +100,12 @@ defmodule StaffNotes.Accounts do
   @doc """
   Deletes the team.
 
-  Will not delete an original team.
+  See `StaffNotes.Accounts.Team.detele_team_changeset/1` for applicable business rules.
   """
-  def delete_team(%Team{original: true} = team) do
-    changeset =
-      team
-      |> change_team()
-      |> Changeset.add_error(:original, "Cannot delete the original team")
-
-    {:error, changeset}
-  end
-
   def delete_team(%Team{} = team) do
-    Repo.delete(team)
+    team
+    |> Team.delete_team_changeset()
+    |> Repo.delete()
   end
 
   @doc """

--- a/lib/staff_notes/accounts/team.ex
+++ b/lib/staff_notes/accounts/team.ex
@@ -12,8 +12,8 @@ defmodule StaffNotes.Accounts.Team do
 
   There are three permission levels:
 
-  * `owner`
-      * All permissions of `write`
+  * `:owner`
+      * All permissions of `:write`
       * Can invite users to the organization
       * Can remove users from the organization
       * If there is only one owner, they can delete the organization
@@ -21,14 +21,14 @@ defmodule StaffNotes.Accounts.Team do
       * Can rename teams
       * Can add or remove users from teams
       * Can view list of users within all teams
-  * `write`
-      * All permissions of `read`
+  * `:write`
+      * All permissions of `:read`
       * Can create members
       * Can create identities
       * Can merge members
       * Can create notes
       * Can edit notes they have authored
-  * `read`
+  * `:read`
       * Can view notes
       * Can view members
       * Can view identities
@@ -36,7 +36,8 @@ defmodule StaffNotes.Accounts.Team do
       * Can view list of users within the organization
       * Can view list of users within teams to which the user belongs
 
-  There can be multiple teams within
+  There can be multiple teams with the same permission level so that an organization can track
+  users how they wish.
 
   ## Original
 
@@ -47,8 +48,8 @@ defmodule StaffNotes.Accounts.Team do
   * It is created with `owner` permission level
   * It cannot be deleted
   * It cannot have its permission level changed
-  * If the team contains one member, they are not allowed to leave the team
-  * If the team contains one member, they are not allowed to leave the organization
+  * If the original team contains one member, they are not allowed to leave the team
+  * If the original team contains one member, they are not allowed to leave the organization
 
   This is done so that there will always be at least one organization member that is capable of
   administrating the organization.

--- a/lib/staff_notes/accounts/team.ex
+++ b/lib/staff_notes/accounts/team.ex
@@ -58,6 +58,7 @@ defmodule StaffNotes.Accounts.Team do
 
   import Ecto.Changeset
 
+  alias StaffNotes.Accounts
   alias StaffNotes.Accounts.Organization
   alias StaffNotes.Accounts.PermissionLevel
   alias StaffNotes.Accounts.Team

--- a/lib/staff_notes/accounts/team.ex
+++ b/lib/staff_notes/accounts/team.ex
@@ -169,8 +169,7 @@ defmodule StaffNotes.Accounts.Team do
 
   defp validate_not_deleting_original_team(changeset) do
     if is_original_team?(changeset) do
-      changeset
-      |> add_error(:original, "Cannot delete the original team")
+      add_error(changeset, :original, "Cannot delete the original team")
     else
       changeset
     end
@@ -187,8 +186,7 @@ defmodule StaffNotes.Accounts.Team do
   defp do_validate_original_field_unchanged(changeset, _, nil), do: changeset
 
   defp do_validate_original_field_unchanged(changeset, _, _) do
-    changeset
-    |> add_error(:original, "A team's original field cannot be changed")
+    add_error(changeset, :original, "A team's original field cannot be changed")
   end
 
   defp validate_original_permission(changeset) do
@@ -199,8 +197,7 @@ defmodule StaffNotes.Accounts.Team do
     case get_field(changeset, :permission) do
       :owner -> changeset
       _ ->
-        changeset
-        |> add_error(:permission, "Cannot change the permission level of the original team")
+        add_error(changeset, :permission, "Cannot change the permission level of the original team")
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -81,6 +81,7 @@ defmodule StaffNotes.Mixfile do
         "Accounts": [
           StaffNotes.Accounts,
           StaffNotes.Accounts.Organization,
+          StaffNotes.Accounts.PermissionLevel,
           StaffNotes.Accounts.Team,
           StaffNotes.Accounts.User
         ],

--- a/spec/staff_notes/accounts/accounts_spec.exs
+++ b/spec/staff_notes/accounts/accounts_spec.exs
@@ -2,13 +2,13 @@ defmodule StaffNotes.AccountsSpec do
   use ESpec
 
   alias StaffNotes.Accounts
-  alias StaffNotes.Accounts.Organization
+  alias StaffNotes.Accounts.Team
   alias StaffNotes.Accounts.User
 
   def org_fixture(attrs \\ %{}) do
     {:ok, org} =
       attrs
-      |> Enum.into(valid_attrs())
+      |> Enum.into(valid_org_attrs())
       |> Accounts.create_org()
 
     org
@@ -19,7 +19,7 @@ defmodule StaffNotes.AccountsSpec do
 
     {:ok, team} =
       attrs
-      |> Enum.into(valid_attrs())
+      |> Enum.into(valid_team_attrs())
       |> Accounts.create_team(org)
 
     team
@@ -34,93 +34,22 @@ defmodule StaffNotes.AccountsSpec do
     user
   end
 
-  describe "organizations" do
-    let :valid_attrs, do: %{name: "some name"}
-    let :update_attrs, do: %{name: "some updated name"}
-    let :invalid_attrs, do: %{name: nil}
+  describe "original_team/1" do
+    let :original_team_attrs, do: Team.original_team_attrs()
+    let :original_team, do: team_fixture(original_team_attrs())
+    let :valid_team_attrs, do: %{name: "team name", permission: :write, original: false}
+    let :valid_org_attrs, do: %{name: "org name"}
 
-    describe "list_orgs/0" do
-      it "returns all orgs" do
-        org = org_fixture()
+    it "returns the original team when one exists" do
+      team = original_team()
 
-        expect(Accounts.list_orgs()).to eq([org])
-      end
+      expect(Accounts.original_team(team.organization_id)).to eq(team)
     end
 
-    describe "get_org!/1" do
-      it "returns the org with the given id" do
-        org = org_fixture()
+    it "returns nil when an original team does not exist" do
+      team = team_fixture(%{name: "some name", permission: :owner, original: false})
 
-        expect(Accounts.get_org!(org.id)).to eq(org)
-      end
-
-      it "raises an exception when given an invalid id" do
-        expect(fn ->
-          Accounts.get_org!(Ecto.UUID.generate())
-        end).to raise_exception(Ecto.NoResultsError)
-      end
-    end
-
-    describe "create_org/1" do
-      it "creates an org when given valid information" do
-        {:ok, %Organization{} = org} = Accounts.create_org(valid_attrs())
-
-        expect(org.name).to eq("some name")
-      end
-
-      it "returns an error changeset when given invalid data" do
-        {:error, changeset} = Accounts.create_org(invalid_attrs())
-
-        expect(changeset).to be_struct(Ecto.Changeset)
-      end
-    end
-
-    describe "update_org/2" do
-      it "updates the org when given valid data" do
-        org = org_fixture()
-        {:ok, org} = Accounts.update_org(org, update_attrs())
-
-        expect(org.name).to eq("some updated name")
-      end
-
-      it "returns an error changeset when given invalid data" do
-        org = org_fixture()
-        {:error, changeset} = Accounts.update_org(org, invalid_attrs())
-
-        expect(changeset).to be_struct(Ecto.Changeset)
-        expect(Accounts.get_org!(org.id)).to eq(org)
-      end
-    end
-
-    describe "delete_org/1" do
-      it "deletes the given org" do
-        org = org_fixture()
-        {:ok, %Organization{}} = Accounts.delete_org(org)
-
-        expect(fn -> Accounts.get_org!(org.id) end).to raise_exception(Ecto.NoResultsError)
-      end
-    end
-
-    describe "change_org/1" do
-      it "returns a org changeset" do
-        org = org_fixture()
-
-        expect(Accounts.change_org(org)).to be_struct(Ecto.Changeset)
-      end
-    end
-
-    describe "original_team/1" do
-      it "returns the original team when one exists" do
-        team = team_fixture(%{name: "some name", permission: :owner, original: true})
-
-        expect(Accounts.original_team(team.organization_id)).to eq(team)
-      end
-
-      it "returns nil when an original team does not exist" do
-        team = team_fixture(%{name: "some name", permission: :owner, original: false})
-
-        expect(Accounts.original_team(team.organization_id)).to be_nil()
-      end
+      expect(Accounts.original_team(team.organization_id)).to be_nil()
     end
   end
 

--- a/spec/staff_notes/accounts/accounts_spec.exs
+++ b/spec/staff_notes/accounts/accounts_spec.exs
@@ -1,10 +1,8 @@
 defmodule StaffNotes.AccountsSpec do
   use ESpec
 
-  alias StaffNotes.Repo
   alias StaffNotes.Accounts
   alias StaffNotes.Accounts.Organization
-  alias StaffNotes.Accounts.Team
   alias StaffNotes.Accounts.User
 
   def org_fixture(attrs \\ %{}) do
@@ -122,118 +120,6 @@ defmodule StaffNotes.AccountsSpec do
         team = team_fixture(%{name: "some name", permission: :owner, original: false})
 
         expect(Accounts.original_team(team.organization_id)).to be_nil()
-      end
-    end
-  end
-
-  describe "teams" do
-    let :valid_attrs, do: %{name: "some name", permission: :owner, original: false}
-    let :update_attrs, do: %{name: "some updated name", permission: :owner, original: true}
-    let :invalid_attrs, do: %{name: nil, permission: nil, original: nil}
-
-    describe "list_teams/1" do
-      it "returns all teams belonging to the given organization" do
-        team_fixture(%{name: "original name"}, %{name: "original org name"})
-        team = team_fixture()
-        %{organization: org} = Repo.preload(team, :organization)
-
-        expect(Accounts.list_teams(org)).to eq([team])
-      end
-    end
-
-    describe "get_team!/1" do
-      it "returns the team with the given id" do
-        team = team_fixture()
-
-        expect(Accounts.get_team!(team.id)).to eq(team)
-      end
-
-      it "raises an exception when given an invalid id" do
-        expect(fn ->
-          Accounts.get_team!(Ecto.UUID.generate())
-        end).to raise_exception(Ecto.NoResultsError)
-      end
-    end
-
-    describe "create_team/1" do
-      it "creates a team when given valid information" do
-        org = org_fixture()
-        {:ok, %Team{} = team} = Accounts.create_team(valid_attrs(), org)
-
-        expect(team.name).to eq("some name")
-        expect(team.permission).to eq(:owner)
-        expect(team.original).to be_false()
-        expect(team.organization_id).to eq(org.id)
-      end
-
-      it "returns an error changeset when given invalid data" do
-        org = org_fixture()
-        {:error, changeset} = Accounts.create_team(invalid_attrs(), org)
-
-        expect(changeset).to be_struct(Ecto.Changeset)
-      end
-
-      it "returns an error changeset when creating the second original team in an org" do
-        team = team_fixture(%{original: true})
-        org = Accounts.get_org!(team.organization_id)
-        {:error, changeset} = Accounts.create_team(update_attrs(), org)
-
-        expect(changeset).to be_struct(Ecto.Changeset)
-      end
-    end
-
-    describe "update_team/2" do
-      it "updates the team when given valid data" do
-        team = team_fixture(%{original: true})
-        {:ok, team} = Accounts.update_team(team, update_attrs())
-
-        expect(team.name).to eq("some updated name")
-      end
-
-      it "returns an error changeset when given invalid data" do
-        team = team_fixture(%{original: true})
-        {:error, changeset} = Accounts.update_team(team, invalid_attrs())
-
-        expect(changeset).to be_struct(Ecto.Changeset)
-        expect(Accounts.get_team!(team.id)).to eq(team)
-      end
-
-      it "returns an error changeset when original is updated" do
-        team = team_fixture(%{original: true})
-        {:error, changeset} = Accounts.update_team(team, %{original: false})
-
-        expect(changeset).to be_struct(Ecto.Changeset)
-      end
-
-      it "returns an error changeset when attempting to change permission level of original team" do
-        team = team_fixture(%{original: true})
-        {:error, changeset} = Accounts.update_team(team, %{permission: :read})
-
-        expect(changeset).to be_struct(Ecto.Changeset)
-      end
-    end
-
-    describe "delete_team/1" do
-      it "deletes the given team" do
-        team = team_fixture()
-        {:ok, %Team{}} = Accounts.delete_team(team)
-
-        expect(fn -> Accounts.get_team!(team.id) end).to raise_exception(Ecto.NoResultsError)
-      end
-
-      it "returns an error changeset when attempting to delete the original team" do
-        team = team_fixture(%{original: true})
-        {:error, changeset} = Accounts.delete_team(team)
-
-        expect(changeset).to be_struct(Ecto.Changeset)
-      end
-    end
-
-    describe "change_team/1" do
-      it "returns a team changeset" do
-        team = team_fixture()
-
-        expect(Accounts.change_team(team)).to be_struct(Ecto.Changeset)
       end
     end
   end

--- a/spec/staff_notes/accounts/organization_spec.exs
+++ b/spec/staff_notes/accounts/organization_spec.exs
@@ -4,6 +4,8 @@ defmodule StaffNotes.Accounts.OrganizationSpec do
   alias StaffNotes.Accounts
   alias StaffNotes.Accounts.Organization
 
+  import ESpec.Phoenix.Assertions.Changeset.Helpers
+
   def org_fixture(attrs \\ %{}) do
     {:ok, org} =
       attrs
@@ -14,23 +16,44 @@ defmodule StaffNotes.Accounts.OrganizationSpec do
   end
 
   describe "organizations" do
+    let :org, do: org_fixture(valid_attrs())
     let :valid_attrs, do: %{name: "some name"}
     let :update_attrs, do: %{name: "some updated name"}
     let :invalid_attrs, do: %{name: nil}
 
-    describe "list_orgs/0" do
-      it "returns all orgs" do
-        org = org_fixture()
+    describe "change_org/1" do
+      it "returns an org changeset" do
+        changeset = Accounts.change_org(org())
 
-        expect(Accounts.list_orgs()).to eq([org])
+        expect(changeset).to be_struct(Ecto.Changeset)
+        expect(changeset).to be_valid()
+      end
+    end
+
+    describe "create_org/1" do
+      it "creates an org when given valid information" do
+        expect(org().name).to eq("some name")
+      end
+
+      it "returns an error changeset when given invalid data" do
+        {:error, %Ecto.Changeset{} = changeset} = Accounts.create_org(invalid_attrs())
+
+        expect(changeset).to_not be_valid()
+        expect(changeset).to have_errors(:name)
+      end
+    end
+
+    describe "delete_org/1" do
+      it "deletes the given org" do
+        {:ok, %Organization{}} = Accounts.delete_org(org())
+
+        expect(fn -> Accounts.get_org!(org().id) end).to raise_exception(Ecto.NoResultsError)
       end
     end
 
     describe "get_org!/1" do
       it "returns the org with the given id" do
-        org = org_fixture()
-
-        expect(Accounts.get_org!(org.id)).to eq(org)
+        expect(Accounts.get_org!(org().id)).to eq(org())
       end
 
       it "raises an exception when given an invalid id" do
@@ -40,51 +63,28 @@ defmodule StaffNotes.Accounts.OrganizationSpec do
       end
     end
 
-    describe "create_org/1" do
-      it "creates an org when given valid information" do
-        {:ok, %Organization{} = org} = Accounts.create_org(valid_attrs())
+    describe "list_orgs/0" do
+      it "returns all orgs" do
+        org = org()
+        list = Accounts.list_orgs()
 
-        expect(org.name).to eq("some name")
-      end
-
-      it "returns an error changeset when given invalid data" do
-        {:error, changeset} = Accounts.create_org(invalid_attrs())
-
-        expect(changeset).to be_struct(Ecto.Changeset)
+        expect(list).to eq([org])
       end
     end
 
     describe "update_org/2" do
       it "updates the org when given valid data" do
-        org = org_fixture()
-        {:ok, org} = Accounts.update_org(org, update_attrs())
+        {:ok, updated_org} = Accounts.update_org(org(), update_attrs())
 
-        expect(org.name).to eq("some updated name")
+        expect(updated_org.name).to eq("some updated name")
       end
 
       it "returns an error changeset when given invalid data" do
-        org = org_fixture()
-        {:error, changeset} = Accounts.update_org(org, invalid_attrs())
+        {:error, %Ecto.Changeset{} = changeset} = Accounts.update_org(org(), invalid_attrs())
 
-        expect(changeset).to be_struct(Ecto.Changeset)
-        expect(Accounts.get_org!(org.id)).to eq(org)
-      end
-    end
-
-    describe "delete_org/1" do
-      it "deletes the given org" do
-        org = org_fixture()
-        {:ok, %Organization{}} = Accounts.delete_org(org)
-
-        expect(fn -> Accounts.get_org!(org.id) end).to raise_exception(Ecto.NoResultsError)
-      end
-    end
-
-    describe "change_org/1" do
-      it "returns a org changeset" do
-        org = org_fixture()
-
-        expect(Accounts.change_org(org)).to be_struct(Ecto.Changeset)
+        expect(changeset).to_not be_valid()
+        expect(changeset).to have_errors(:name)
+        expect(Accounts.get_org!(org().id)).to eq(org())
       end
     end
   end

--- a/spec/staff_notes/accounts/organization_spec.exs
+++ b/spec/staff_notes/accounts/organization_spec.exs
@@ -1,0 +1,91 @@
+defmodule StaffNotes.Accounts.OrganizationSpec do
+  use ESpec
+
+  alias StaffNotes.Accounts
+  alias StaffNotes.Accounts.Organization
+
+  def org_fixture(attrs \\ %{}) do
+    {:ok, org} =
+      attrs
+      |> Enum.into(valid_attrs())
+      |> Accounts.create_org()
+
+    org
+  end
+
+  describe "organizations" do
+    let :valid_attrs, do: %{name: "some name"}
+    let :update_attrs, do: %{name: "some updated name"}
+    let :invalid_attrs, do: %{name: nil}
+
+    describe "list_orgs/0" do
+      it "returns all orgs" do
+        org = org_fixture()
+
+        expect(Accounts.list_orgs()).to eq([org])
+      end
+    end
+
+    describe "get_org!/1" do
+      it "returns the org with the given id" do
+        org = org_fixture()
+
+        expect(Accounts.get_org!(org.id)).to eq(org)
+      end
+
+      it "raises an exception when given an invalid id" do
+        expect(fn ->
+          Accounts.get_org!(Ecto.UUID.generate())
+        end).to raise_exception(Ecto.NoResultsError)
+      end
+    end
+
+    describe "create_org/1" do
+      it "creates an org when given valid information" do
+        {:ok, %Organization{} = org} = Accounts.create_org(valid_attrs())
+
+        expect(org.name).to eq("some name")
+      end
+
+      it "returns an error changeset when given invalid data" do
+        {:error, changeset} = Accounts.create_org(invalid_attrs())
+
+        expect(changeset).to be_struct(Ecto.Changeset)
+      end
+    end
+
+    describe "update_org/2" do
+      it "updates the org when given valid data" do
+        org = org_fixture()
+        {:ok, org} = Accounts.update_org(org, update_attrs())
+
+        expect(org.name).to eq("some updated name")
+      end
+
+      it "returns an error changeset when given invalid data" do
+        org = org_fixture()
+        {:error, changeset} = Accounts.update_org(org, invalid_attrs())
+
+        expect(changeset).to be_struct(Ecto.Changeset)
+        expect(Accounts.get_org!(org.id)).to eq(org)
+      end
+    end
+
+    describe "delete_org/1" do
+      it "deletes the given org" do
+        org = org_fixture()
+        {:ok, %Organization{}} = Accounts.delete_org(org)
+
+        expect(fn -> Accounts.get_org!(org.id) end).to raise_exception(Ecto.NoResultsError)
+      end
+    end
+
+    describe "change_org/1" do
+      it "returns a org changeset" do
+        org = org_fixture()
+
+        expect(Accounts.change_org(org)).to be_struct(Ecto.Changeset)
+      end
+    end
+  end
+end

--- a/spec/staff_notes/accounts/team_spec.exs
+++ b/spec/staff_notes/accounts/team_spec.exs
@@ -1,0 +1,175 @@
+defmodule StaffNotes.Accounts.TeamSpec do
+  use ESpec
+
+  alias StaffNotes.Accounts
+  alias StaffNotes.Accounts.Team
+
+  import Spec.Helpers
+  import ESpec.Phoenix.Assertions.Changeset.Helpers
+
+  describe "teams" do
+    def org_fixture(attrs) do
+      {:ok, org} =
+        %{}
+        |> merge_attrs(attrs)
+        |> Accounts.create_org()
+
+      org
+    end
+
+    def team_fixture(attrs \\ %{}, org \\ org()) do
+      {:ok, team} =
+        regular_team_attrs()
+        |> merge_attrs(attrs)
+        |> Accounts.create_team(org)
+
+      team
+    end
+
+    let :org, do: org_fixture(name: "org name")
+    let :other_org, do: org_fixture(name: "other org name")
+
+    let :original_team_attrs, do: Team.original_team_attrs()
+    let :regular_team_attrs, do: %{name: "some name", permission: :write, original: false}
+    let :other_team_attrs, do: %{name: "some other name", permission: :read, original: false}
+
+    let :valid_attrs, do: %{name: "some name", permission: :write, original: false}
+    let :update_attrs, do: %{name: "some updated name", permission: :owner, original: true}
+    let :invalid_attrs, do: %{name: nil, permission: nil, original: nil}
+
+    let :original_team, do: team_fixture(original_team_attrs())
+    let :regular_team, do: team_fixture(regular_team_attrs())
+
+    describe "change_team/1" do
+      it "returns a team changeset" do
+        team = team_fixture()
+        changeset = Accounts.change_team(team)
+
+        expect(changeset).to be_struct(Ecto.Changeset)
+        expect(changeset).to be_valid()
+      end
+    end
+
+    describe "create_team/1" do
+      it "creates a team when given valid information" do
+        {:ok, %Team{} = team} = Accounts.create_team(regular_team_attrs(), org())
+
+        expect(team.name).to eq("some name")
+        expect(team.permission).to eq(:write)
+        expect(team.original).to be_false()
+        expect(team.organization_id).to eq(org().id)
+      end
+
+      it "returns an error changeset when given invalid data" do
+        {:error, %Ecto.Changeset{} = changeset} = Accounts.create_team(invalid_attrs(), org())
+
+        expect(changeset).to_not be_valid()
+        expect(changeset).to have_errors([:name, :permission, :original])
+      end
+
+      it "returns an error changeset when creating the second original team in an org" do
+        _original_team = original_team()
+        {:error, %Ecto.Changeset{} = changeset} = Accounts.create_team(%{original: true}, org())
+
+        expect(changeset).to_not be_valid()
+        expect(changeset).to have_errors(:original)
+      end
+    end
+
+    describe "delete_team/1" do
+      it "deletes the given team" do
+        _original_team = original_team()
+        team = team_fixture()
+        {:ok, %Team{}} = Accounts.delete_team(team)
+
+        expect(fn -> Accounts.get_team!(team.id) end).to raise_exception(Ecto.NoResultsError)
+      end
+
+      it "returns an error changeset when attempting to delete the original team" do
+        {:error, %Ecto.Changeset{} = changeset} = Accounts.delete_team(original_team())
+
+        expect(changeset).to_not be_valid()
+        expect(changeset).to have_errors(:original)
+      end
+    end
+
+    describe "get_team!/1" do
+      it "returns the team with the given id" do
+        team = regular_team()
+
+        expect(Accounts.get_team!(team.id)).to eq(team)
+      end
+
+      it "raises an exception when given an invalid id" do
+        expect(fn ->
+          Accounts.get_team!(Ecto.UUID.generate())
+        end).to raise_exception(Ecto.NoResultsError)
+      end
+    end
+
+    describe "list_teams/1" do
+      it "returns all teams belonging to the given organization" do
+        _team_in_other_org = team_fixture(regular_team_attrs(), other_org())
+        team = regular_team()
+        list = Accounts.list_teams(org())
+
+        expect(list).to eq([team])
+      end
+    end
+
+    describe "update_team/2" do
+      it "updates the original team when given valid data" do
+        original_team = original_team()
+        {:ok, %Team{} = team} = Accounts.update_team(original_team, %{name: "some updated name"})
+
+        expect(team.name).to eq("some updated name")
+        expect(team.permission).to eq(:owner)
+        expect(team.original).to be_true()
+        expect(team.organization_id).to eq(original_team.organization_id)
+      end
+
+      it "updates a regular team when given valid data" do
+        regular_team = regular_team()
+        {:ok, %Team{} = team} = Accounts.update_team(regular_team, %{name: "some updated name"})
+
+        expect(team.name).to eq("some updated name")
+        expect(team.permission).to eq(:write)
+        expect(team.original).to be_false()
+        expect(team.organization_id).to eq(regular_team.organization_id)
+      end
+
+      it "returns an error changeset when given invalid data" do
+        team = regular_team()
+        {:error, %Ecto.Changeset{} = changeset} = Accounts.update_team(team, invalid_attrs())
+
+        expect(changeset).to_not be_valid()
+        expect(changeset).to have_errors([:name, :permission, :original])
+        expect(Accounts.get_team!(team.id)).to eq(team)
+      end
+
+      it "returns an error changeset when trying to mark original team not original" do
+        team = original_team()
+        {:error, %Ecto.Changeset{} = changeset} = Accounts.update_team(team, %{original: false})
+
+        expect(changeset).to_not be_valid()
+        expect(changeset).to have_errors(:original)
+      end
+
+      it "returns an error changeset when trying to mark an unoriginal team as original" do
+        team = regular_team()
+        {:error, %Ecto.Changeset{} = changeset} = Accounts.update_team(team, %{original: true})
+
+        expect(changeset).to_not be_valid()
+        expect(changeset).to have_errors(:original)
+      end
+
+      it "returns an error changeset when attempting to change permission level of original team" do
+        team = original_team()
+        {:error, %Ecto.Changeset{} = changeset} = Accounts.update_team(team, %{permission: :read})
+
+        expect(changeset).to_not be_valid()
+        expect(changeset).to have_errors(:permission)
+      end
+    end
+  end
+end

--- a/spec/support/assertions/changeset/be_valid.ex
+++ b/spec/support/assertions/changeset/be_valid.ex
@@ -1,0 +1,20 @@
+defmodule ESpec.Phoenix.Assertions.Changeset.BeValid do
+
+  use ESpec.Assertions.Interface
+
+  defp match(changeset, _value) do
+    {changeset.valid?, changeset.valid?}
+  end
+
+  defp success_message(changeset, _value, _result, positive) do
+    be = if positive, do: "is", else: "is not"
+    "`#{inspect changeset}` #{be} valid."
+  end
+
+  defp error_message(changeset, _value, _result, positive) do
+    be = if positive, do: "be", else: "not to be"
+    but = if positive, do: "it is not", else: "it is"
+    "Expected `#{inspect changeset}` to #{be} valid, but #{but}."
+  end
+
+end

--- a/spec/support/assertions/changeset/have_errors.ex
+++ b/spec/support/assertions/changeset/have_errors.ex
@@ -1,0 +1,38 @@
+defmodule ESpec.Phoenix.Assertions.Changeset.HaveErrors do
+  @moduledoc """
+  Implements the `have_errors` matcher.
+
+  It expects the supplied field or list of fields to be present in the list of errors in the
+  changeset.
+  """
+  use ESpec.Assertions.Interface
+
+  defp match(changeset, list) when is_list(list) do
+    result = if Keyword.keyword?(list) do
+      Enum.all?(list, &Enum.member?(changeset.errors, &1))
+    else
+      keys = Keyword.keys(changeset.errors)
+      Enum.all?(list, &Enum.member?(keys, &1))
+    end
+
+    {result, result}
+  end
+
+  defp match(changeset, value) do
+    result = Enum.member?(Keyword.keys(changeset.errors), value)
+    {result, result}
+  end
+
+  defp success_message(changeset, value, _result, positive) do
+    has = if positive, do: "has", else: "does not have"
+
+    "`#{inspect changeset}` #{has} errors `#{inspect value}`"
+  end
+
+  defp error_message(changeset, value, _result, positive) do
+    have = if positive, do: "to have", else: "not to have"
+    but = if positive, do: "it does not", else: "it does"
+
+    "Expected `#{inspect changeset}` #{have} errors `#{inspect value}`, but #{but}"
+  end
+end

--- a/spec/support/assertions/changeset/helpers.ex
+++ b/spec/support/assertions/changeset/helpers.ex
@@ -1,0 +1,4 @@
+defmodule ESpec.Phoenix.Assertions.Changeset.Helpers do
+  def be_valid, do: {ESpec.Phoenix.Assertions.Changeset.BeValid, []}
+  def have_errors(value), do: {ESpec.Phoenix.Assertions.Changeset.HaveErrors, value}
+end

--- a/spec/support/helpers.ex
+++ b/spec/support/helpers.ex
@@ -1,0 +1,6 @@
+defmodule Spec.Helpers do
+  @doc """
+  Merges `additional` attributes with `base`.
+  """
+  def merge_attrs(base, additional), do: Enum.into(additional, base)
+end


### PR DESCRIPTION
Protects the original team from improper changes or deletions to ensure that there is always at least one team with owner permissions for every organization.