### PR TITLE
Rename the plug to TokenAuthentication

### DIFF
--- a/lib/router.ex
+++ b/lib/router.ex
@@ -5,6 +5,7 @@ defmodule StaffNotesWeb.Router do
   use StaffNotesWeb, :router
 
   alias Plug.Ribbon
+  alias StaffNotesApi.TokenAuthentication
   alias StaffNotesWeb.SlidingSessionTimeout
 
   pipeline :browser do
@@ -20,6 +21,7 @@ defmodule StaffNotesWeb.Router do
 
   pipeline :api do
     plug(:accepts, ["json"])
+    plug(TokenAuthentication)
   end
 
   scope "/", StaffNotesWeb do

--- a/lib/staff_notes_api/controllers/file_controller.ex
+++ b/lib/staff_notes_api/controllers/file_controller.ex
@@ -6,8 +6,6 @@ defmodule StaffNotesApi.FileController do
 
   alias StaffNotes.Files
 
-  plug StaffNotesApi.TokenAuthentication
-
   @doc """
   Accepts a base64-encoded file, uploads it to S3, and returns the URL where it can be viewed.
 

--- a/lib/staff_notes_api/controllers/file_controller.ex
+++ b/lib/staff_notes_api/controllers/file_controller.ex
@@ -6,7 +6,7 @@ defmodule StaffNotesApi.FileController do
 
   alias StaffNotes.Files
 
-  plug StaffNotesApi.AuthTokenPlug
+  plug StaffNotesApi.TokenAuthentication
 
   @doc """
   Accepts a base64-encoded file, uploads it to S3, and returns the URL where it can be viewed.

--- a/lib/staff_notes_api/controllers/markdown_controller.ex
+++ b/lib/staff_notes_api/controllers/markdown_controller.ex
@@ -6,7 +6,7 @@ defmodule StaffNotesApi.MarkdownController do
 
   alias StaffNotes.Ecto.Markdown
 
-  plug StaffNotesApi.AuthTokenPlug
+  plug StaffNotesApi.TokenAuthentication
 
   @doc """
   Renders the Markdown received and returns an HTML fragment.

--- a/lib/staff_notes_api/controllers/markdown_controller.ex
+++ b/lib/staff_notes_api/controllers/markdown_controller.ex
@@ -6,8 +6,6 @@ defmodule StaffNotesApi.MarkdownController do
 
   alias StaffNotes.Ecto.Markdown
 
-  plug StaffNotesApi.TokenAuthentication
-
   @doc """
   Renders the Markdown received and returns an HTML fragment.
 

--- a/lib/staff_notes_api/plugs/token_authentication.ex
+++ b/lib/staff_notes_api/plugs/token_authentication.ex
@@ -1,4 +1,4 @@
-defmodule StaffNotesApi.AuthTokenPlug do
+defmodule StaffNotesApi.TokenAuthentication do
   @moduledoc """
   A module `Plug` for validating the API token in the authorization request header.
 
@@ -32,14 +32,14 @@ defmodule StaffNotesApi.AuthTokenPlug do
   Default options:
 
   ```
-  iex> StaffNotesApi.AuthTokenPlug.init()
+  iex> StaffNotesApi.TokenAuthentication.init()
   [api_access_salt: "api-access-salt", max_age: 86_400]
   ```
 
   Overriding options:
 
   ```
-  iex> StaffNotesApi.AuthTokenPlug.init(api_access_salt: "test", max_age: 1_000)
+  iex> StaffNotesApi.TokenAuthentication.init(api_access_salt: "test", max_age: 1_000)
   [api_access_salt: "test", max_age: 1_000]
   ```
   """

--- a/lib/staff_notes_web/helpers/api_token_helpers.ex
+++ b/lib/staff_notes_web/helpers/api_token_helpers.ex
@@ -6,13 +6,13 @@ defmodule StaffNotesWeb.ApiTokenHelpers do
 
   alias Phoenix.Token
 
-  alias StaffNotesApi.AuthTokenPlug
+  alias StaffNotesApi.TokenAuthentication
 
   @doc """
   Generates an API access token for the currently signed-in user.
   """
   def generate_api_token(conn) do
-    Token.sign(conn, AuthTokenPlug.init()[:api_access_salt], current_user_id(conn))
+    Token.sign(conn, TokenAuthentication.init()[:api_access_salt], current_user_id(conn))
   end
 
   @doc """

--- a/test/staff_notes_api/plugs/token_authentication_test.exs
+++ b/test/staff_notes_api/plugs/token_authentication_test.exs
@@ -1,6 +1,6 @@
-defmodule StaffNotesApi.AuthTokenPlugTest do
+defmodule StaffNotesApi.TokenAuthenticationTest do
   use StaffNotesWeb.ConnCase
-  doctest StaffNotesApi.AuthTokenPlug
+  doctest StaffNotesApi.TokenAuthentication
 
   require Logger
 
@@ -8,7 +8,7 @@ defmodule StaffNotesApi.AuthTokenPlugTest do
 
   alias Phoenix.Token
   alias StaffNotesApi.AuthenticationError
-  alias StaffNotesApi.AuthTokenPlug
+  alias StaffNotesApi.TokenAuthentication
 
   defp put_auth_header(conn, token) do
     put_req_header(conn, "authorization", "token #{token}")
@@ -22,19 +22,19 @@ defmodule StaffNotesApi.AuthTokenPlugTest do
     token = Token.sign(@endpoint, salt, id)
     conn = put_private(context.conn, :phoenix_endpoint, @endpoint)
 
-    {:ok, conn: conn, id: id, options: AuthTokenPlug.init(), salt: salt, valid_token: token}
+    {:ok, conn: conn, id: id, options: TokenAuthentication.init(), salt: salt, valid_token: token}
   end
 
   describe "calling the plug" do
     test "with a valid token", context do
       conn = put_auth_header(context.conn, context.valid_token)
 
-      assert %Plug.Conn{} = AuthTokenPlug.call(conn, context.options)
+      assert %Plug.Conn{} = TokenAuthentication.call(conn, context.options)
     end
 
     test "without an auth header", context do
       assert_raise AuthenticationError, "`Authorization` request header missing or malformed", fn ->
-        AuthTokenPlug.call(context.conn, context.options)
+        TokenAuthentication.call(context.conn, context.options)
       end
     end
 
@@ -42,7 +42,7 @@ defmodule StaffNotesApi.AuthTokenPlugTest do
       conn = put_req_header(context.conn, "authorization", "foo")
 
       assert_raise AuthenticationError, "`Authorization` request header missing or malformed", fn ->
-        AuthTokenPlug.call(conn, context.options)
+        TokenAuthentication.call(conn, context.options)
       end
     end
 
@@ -50,7 +50,7 @@ defmodule StaffNotesApi.AuthTokenPlugTest do
       conn = put_auth_header(context.conn, "foo")
 
       assert_raise AuthenticationError, "Authentication token is invalid", fn ->
-        AuthTokenPlug.call(conn, context.options)
+        TokenAuthentication.call(conn, context.options)
       end
     end
 
@@ -58,7 +58,7 @@ defmodule StaffNotesApi.AuthTokenPlugTest do
       conn = put_auth_header(context.conn, Token.sign(@endpoint, context.salt, 69))
 
       assert_raise AuthenticationError, "Authentication token is invalid", fn ->
-        AuthTokenPlug.call(conn, context.options)
+        TokenAuthentication.call(conn, context.options)
       end
     end
 
@@ -66,7 +66,7 @@ defmodule StaffNotesApi.AuthTokenPlugTest do
       conn = put_auth_header(context.conn, Token.sign(@endpoint, context.salt, nil))
 
       assert_raise AuthenticationError, "Not logged in", fn ->
-        AuthTokenPlug.call(conn, context.options)
+        TokenAuthentication.call(conn, context.options)
       end
     end
 
@@ -74,7 +74,7 @@ defmodule StaffNotesApi.AuthTokenPlugTest do
       conn = put_auth_header(context.conn, context.valid_token)
 
       assert_raise AuthenticationError, "Authentication token is expired", fn ->
-        AuthTokenPlug.call(conn, AuthTokenPlug.init(max_age: -100))
+        TokenAuthentication.call(conn, TokenAuthentication.init(max_age: -100))
       end
     end
   end


### PR DESCRIPTION
Having `Plug` in the name of a plug seems weird because you include them by calling the `plug` function on them ... so then it's `plug(SomethingPlug)` 🤮