### PR TITLE
Split the Ecto type and Markdown struct into their own modules

### DIFF
--- a/lib/staff_notes/ecto/markdown.ex
+++ b/lib/staff_notes/ecto/markdown.ex
@@ -1,6 +1,7 @@
 defmodule StaffNotes.Ecto.Markdown do
   @moduledoc """
-  An `Ecto.Type` that represents a chunk of [Markdown](http://commonmark.org) to be rendered.
+  An `Ecto.Type` that handles the conversion between a string in the database and a
+  `StaffNotes.Markdown` struct in memory.
 
   Use this as the type of the database field in the schema:
 
@@ -24,11 +25,6 @@ defmodule StaffNotes.Ecto.Markdown do
 
   [beyond-functions]: https://blog.usejournal.com/beyond-functions-in-elixir-refactoring-for-maintainability-5c73daba77f3
   """
-  @type t :: %__MODULE__{text: String.t(), html: nil | String.t()}
-  defstruct text: "", html: nil
-
-  @type markdown :: %__MODULE__{} | String.t()
-
   @behaviour Ecto.Type
 
   @impl Ecto.Type
@@ -36,80 +32,24 @@ defmodule StaffNotes.Ecto.Markdown do
 
   @impl Ecto.Type
   def cast(binary) when is_binary(binary) do
-    {:ok, %__MODULE__{text: binary}}
+    {:ok, %StaffNotes.Markdown{text: binary}}
   end
 
-  def cast(%__MODULE__{} = markdown), do: {:ok, markdown}
+  def cast(%StaffNotes.Markdown{} = markdown), do: {:ok, markdown}
   def cast(_other), do: :error
 
   @impl Ecto.Type
   def load(binary) when is_binary(binary) do
-    {:ok, %__MODULE__{text: binary, html: to_html(binary)}}
+    {:ok, %StaffNotes.Markdown{text: binary, html: StaffNotes.Markdown.to_html(binary)}}
   end
 
   def load(_other), do: :error
 
   @impl Ecto.Type
-  def dump(%__MODULE__{text: binary}) when is_binary(binary) do
+  def dump(%StaffNotes.Markdown{text: binary}) when is_binary(binary) do
     {:ok, binary}
   end
 
   def dump(binary) when is_binary(binary), do: {:ok, binary}
   def dump(_other), do: :error
-
-  @doc """
-  Renders the supplied Markdown as HTML.
-
-  ## Examples
-
-  Render Markdown from a string:
-
-  ```
-  iex> StaffNotes.Ecto.Markdown.to_html("# Foo")
-  "<h1>Foo</h1>\n"
-  ```
-
-  Render Markdown from an unrendered `Markdown` struct:
-
-  ```
-  iex> StaffNotes.Ecto.Markdown.to_html(%StaffNotes.Ecto.Markdown{text: "# Foo"})
-  "<h1>Foo</h1>\n"
-  ```
-
-  Passes already rendered Markdown through unchanged:
-
-  ```
-  iex> StaffNotes.Ecto.Markdown.to_html(%StaffNotes.Ecto.Markdown{html: "<p>foo</p>"})
-  "<p>foo</p>"
-  ```
-
-  Returns an empty string for anything that isn't a string or a `Markdown` struct:
-
-  ```
-  iex> StaffNotes.Ecto.Markdown.to_html(5)
-  ""
-  ```
-  """
-  @spec to_html(markdown) :: String.t()
-  def to_html(markdown)
-
-  def to_html(%__MODULE__{html: html}) when is_binary(html), do: html
-  def to_html(%__MODULE__{text: text}), do: to_html(text)
-
-  def to_html(text) when is_binary(text) do
-    Cmark.to_html(text, [:safe, :smart])
-  end
-
-  def to_html(_other), do: ""
-
-  @doc """
-  Converts a block of markdown to iodata.
-  """
-  def to_iodata(%__MODULE__{} = markdown), do: to_html(markdown)
-
-  defimpl Phoenix.HTML.Safe do
-    def to_iodata(%StaffNotes.Ecto.Markdown{} = markdown) do
-      StaffNotes.Ecto.Markdown.to_iodata(markdown)
-    end
-  end
 end

--- a/lib/staff_notes/markdown.ex
+++ b/lib/staff_notes/markdown.ex
@@ -1,0 +1,62 @@
+defmodule StaffNotes.Markdown do
+  @moduledoc """
+  A structure that epresents a chunk of Markdown to be rendered.
+  """
+  @type t :: %__MODULE__{text: String.t(), html: nil | String.t()}
+  defstruct text: "", html: nil
+
+  @type markdown :: %__MODULE__{} | String.t()
+
+  @doc """
+  Renders the supplied Markdown as HTML.
+
+  ## Examples
+
+  Render Markdown from a string:
+
+  ```
+  iex> StaffNotes.Markdown.to_html("# Foo")
+  "<h1>Foo</h1>\n"
+  ```
+
+  Render Markdown from an unrendered `Markdown` struct:
+
+  ```
+  iex> StaffNotes.Markdown.to_html(%StaffNotes.Markdown{text: "# Foo"})
+  "<h1>Foo</h1>\n"
+  ```
+
+  Passes already rendered Markdown through unchanged:
+
+  ```
+  iex> StaffNotes.Markdown.to_html(%StaffNotes.Markdown{html: "<p>foo</p>"})
+  "<p>foo</p>"
+  ```
+
+  Returns an empty string for anything that isn't a string or a `Markdown` struct:
+
+  ```
+  iex> StaffNotes.Markdown.to_html(5)
+  ""
+  ```
+  """
+  @spec to_html(markdown) :: binary
+  def to_html(markdown)
+
+  def to_html(%__MODULE__{html: html}) when is_binary(html), do: html
+  def to_html(%__MODULE__{text: text}) when is_binary(text), do: to_html(text)
+
+  def to_html(binary) when is_binary(binary) do
+    Cmark.to_html(binary, [:safe, :smart])
+  end
+
+  def to_html(_), do: ""
+
+  def to_iodata(%__MODULE__{} = markdown), do: to_html(markdown)
+
+  defimpl Phoenix.HTML.Safe do
+    def to_iodata(%StaffNotes.Markdown{} = markdown) do
+      StaffNotes.Markdown.to_iodata(markdown)
+    end
+  end
+end

--- a/lib/staff_notes_api/controllers/markdown_controller.ex
+++ b/lib/staff_notes_api/controllers/markdown_controller.ex
@@ -4,7 +4,7 @@ defmodule StaffNotesApi.MarkdownController do
   """
   use StaffNotesApi, :controller
 
-  alias StaffNotes.Ecto.Markdown
+  alias StaffNotes.Markdown
 
   @doc """
   Renders the Markdown received and returns an HTML fragment.

--- a/lib/staff_notes_web/helpers/primer_helpers.ex
+++ b/lib/staff_notes_web/helpers/primer_helpers.ex
@@ -8,7 +8,7 @@ defmodule StaffNotesWeb.PrimerHelpers do
   import PhoenixOcticons
 
   alias Phoenix.HTML.Form
-  alias StaffNotes.Ecto.Markdown
+  alias StaffNotes.Markdown
   alias StaffNotesWeb.ErrorHelpers
   alias StaffNotesWeb.Primer
 

--- a/lib/staff_notes_web/markdown_engine.ex
+++ b/lib/staff_notes_web/markdown_engine.ex
@@ -4,7 +4,7 @@ defmodule StaffNotesWeb.MarkdownEngine do
   """
   @behaviour Slime.Parser.EmbeddedEngine
 
-  alias StaffNotes.Ecto.Markdown
+  alias StaffNotes.Markdown
 
   def render(text, _options), do: Markdown.to_html(text)
 end

--- a/test/staff_notes/ecto/markdown_test.exs
+++ b/test/staff_notes/ecto/markdown_test.exs
@@ -3,11 +3,51 @@ defmodule StaffNotes.Ecto.MarkdownTest do
 
   alias StaffNotes.Ecto.Markdown
 
-  doctest Markdown
+  describe "casting" do
+    test "a binary returns a Markdown struct" do
+      {:ok, %StaffNotes.Markdown{}} = Markdown.cast("foo")
+    end
 
-  describe "Phoenix.HTML.Safe" do
-    test "implements the protocol" do
-      assert Phoenix.HTML.Safe.to_iodata(%Markdown{text: "# Foo"}) =~ "<h1>Foo</h1>"
+    test "a Markdown struct returns the struct" do
+      {:ok, %StaffNotes.Markdown{} = markdown} = Markdown.cast(%StaffNotes.Markdown{text: "test"})
+
+      assert markdown.text == "test"
+      assert is_nil(markdown.html)
+    end
+
+    test "anything else returns an error" do
+      assert :error == Markdown.cast(7)
+    end
+  end
+
+  describe "loading" do
+    test "a binary returns a rendered Markdown struct" do
+      {:ok, %StaffNotes.Markdown{} = markdown} = Markdown.load("test")
+
+      assert markdown.text == "test"
+      assert markdown.html == "<p>test</p>\n"
+    end
+
+    test "anything else returns an error" do
+      assert :error == Markdown.load(7)
+    end
+  end
+
+  describe "dumping" do
+    test "a Markdown struct returns the text value" do
+      {:ok, text} = Markdown.dump(%StaffNotes.Markdown{text: "test"})
+
+      assert text == "test"
+    end
+
+    test "a binary returns the binary" do
+      {:ok, text} = Markdown.dump("test")
+
+      assert text == "test"
+    end
+
+    test "anything else returns an error" do
+      assert :error == Markdown.dump(7)
     end
   end
 end

--- a/test/staff_notes/markdown_test.exs
+++ b/test/staff_notes/markdown_test.exs
@@ -1,0 +1,14 @@
+defmodule StaffNotes.MarkdownTest do
+  use ExUnit.Case, async: true
+  doctest StaffNotes.Markdown
+
+  import Phoenix.HTML.Safe, only: [to_iodata: 1]
+
+  alias StaffNotes.Markdown
+
+  describe "Phoenix.HTML.Safe" do
+    test "implements the protocol" do
+      assert to_iodata(%Markdown{text: "# Foo"}) =~ "<h1>Foo</h1>"
+    end
+  end
+end

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -25,7 +25,7 @@ defmodule StaffNotes.Support.Helpers do
   alias StaffNotes.Accounts
   alias StaffNotes.Accounts.User
   alias StaffNotes.Accounts.Organization
-  alias StaffNotes.Ecto.Markdown
+  alias StaffNotes.Markdown
   alias StaffNotes.Notes
   alias StaffNotes.Notes.Note
   alias StaffNotesWeb.ErrorView


### PR DESCRIPTION
I found that having the Ecto type and the Markdown struct in separate modules made for better testability and separation of concerns.